### PR TITLE
Fix a bug preventing sync root in folder on drive roots

### DIFF
--- a/src/common/vfs.cpp
+++ b/src/common/vfs.cpp
@@ -71,7 +71,7 @@ Result<void, QString> Vfs::checkAvailability(const QString &path, Vfs::Mode mode
 #ifdef Q_OS_WIN
     if (mode == Mode::WindowsCfApi) {
         const auto info = QFileInfo(path);
-        if (QDir(info.canonicalPath()).isRoot()) {
+        if (QDir(info.canonicalFilePath()).isRoot()) {
             return tr("The Virtual filesystem feature does not support a drive as sync root");
         }
         const auto fs = FileSystem::fileSystemForPath(info.absoluteFilePath());

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -2044,9 +2044,9 @@ bool FolderMan::checkVfsAvailability(const QString &path, Vfs::Mode mode) const
 Result<void, QString> FolderMan::unsupportedConfiguration(const QString &path) const
 {
     if (numberOfSyncJournals(path) > 1) {
-        return tr("Multiple accounts are sharing the folder %1.\n"
-                  "This configuration is known to lead to data loss and is no longer supported.\n"
-                  "Please consider removing this folder from the account and adding it again.")
+        return tr("The folder %1 is linked to multiple accounts.\n"
+                  "This setup can cause data loss and is no longer supported. To resolve this issue, please remove this folder from one of the accounts and add it again.\n\n"
+                  "For advanced users: This issue might be related to an older database file. Check the folder for outdated .db files and remove them if necessary.")
             .arg(path);
     }
     return {};

--- a/src/gui/folderman.cpp
+++ b/src/gui/folderman.cpp
@@ -2045,8 +2045,9 @@ Result<void, QString> FolderMan::unsupportedConfiguration(const QString &path) c
 {
     if (numberOfSyncJournals(path) > 1) {
         return tr("The folder %1 is linked to multiple accounts.\n"
-                  "This setup can cause data loss and is no longer supported. To resolve this issue, please remove this folder from one of the accounts and add it again.\n\n"
-                  "For advanced users: This issue might be related to an older database file. Check the folder for outdated .db files and remove them if necessary.")
+                  "This setup can cause data loss and it is no longer supported.\n"
+                  "To resolve this issue: please remove %1 from one of the accounts and create a new sync folder.\n\n"
+                  "For advanced users: this issue might be related to multiple sync database files found in one folder. Please check %1 for outdated and unused .sync_*.db files and remove them.")
             .arg(path);
     }
     return {};

--- a/translations/client_da.ts
+++ b/translations/client_da.ts
@@ -171,7 +171,7 @@
     <message>
         <location filename="../src/gui/tray/CurrentAccountHeaderButton.qml" line="36"/>
         <source>Current account</source>
-        <translation type="unfinished"/>
+        <translation>Nuværende konto</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/CurrentAccountHeaderButton.qml" line="42"/>
@@ -188,22 +188,22 @@
     <message>
         <location filename="../src/gui/tray/CurrentAccountHeaderButton.qml" line="95"/>
         <source>Add account</source>
-        <translation type="unfinished"/>
+        <translation>Tilføj konto</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/CurrentAccountHeaderButton.qml" line="99"/>
         <source>Add new account</source>
-        <translation type="unfinished"/>
+        <translation>Tilføj ny konto</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/CurrentAccountHeaderButton.qml" line="122"/>
         <source>Settings</source>
-        <translation type="unfinished"/>
+        <translation>Indstillinger</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/CurrentAccountHeaderButton.qml" line="133"/>
         <source>Exit</source>
-        <translation type="unfinished"/>
+        <translation>Afslut</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/CurrentAccountHeaderButton.qml" line="161"/>
@@ -1323,7 +1323,7 @@ Denne handling vil annullere alle i øjeblikket kørende synkroniseringer.</tran
     <message>
         <location filename="../src/libsync/bulkpropagatorjob.cpp" line="649"/>
         <source>The local file was removed during sync.</source>
-        <translation type="unfinished"/>
+        <translation>Den lokale fil blev fjernet under synkronisering.</translation>
     </message>
     <message>
         <location filename="../src/libsync/bulkpropagatorjob.cpp" line="697"/>
@@ -2566,7 +2566,7 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/folderstatusmodel.cpp" line="331"/>
         <source>Synchronizing files in local folder</source>
-        <translation type="unfinished"/>
+        <translation>Synkroniserer filer i lokal mappe</translation>
     </message>
     <message>
         <location filename="../src/gui/folderstatusmodel.cpp" line="993"/>
@@ -2907,7 +2907,7 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/generalsettings.ui" line="50"/>
         <source>Show Chat Notifications</source>
-        <translation type="unfinished"/>
+        <translation>Vis chatnotifikationer</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="89"/>
@@ -2922,7 +2922,7 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/generalsettings.ui" line="80"/>
         <source>Ask for confirmation before synchronizing new folders larger than</source>
-        <translation type="unfinished"/>
+        <translation>Bed om bekræftelse, før du synkroniserer nye mapper større end</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="106"/>
@@ -2932,7 +2932,7 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/generalsettings.ui" line="114"/>
         <source>&amp;Automatically check for Updates</source>
-        <translation>Søg &amp;automatisk efter opdateringer</translation>
+        <translation>&amp;Søg automatisk efter opdateringer</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="249"/>
@@ -2948,12 +2948,12 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/generalsettings.ui" line="143"/>
         <source>Notify when synchronised folders grow larger than specified limit</source>
-        <translation type="unfinished"/>
+        <translation>Giv besked, når synkroniserede mapper bliver større end den angivne grænse</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="170"/>
         <source>Automatically disable synchronisation of folders that overcome limit</source>
-        <translation type="unfinished"/>
+        <translation>Deaktiver automatisk synkronisering af mapper, der overskrider grænsen</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="273"/>
@@ -2963,7 +2963,7 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/generalsettings.ui" line="194"/>
         <source>Move removed files to trash</source>
-        <translation type="unfinished"/>
+        <translation>Flyt fjernede filer til papirkurven</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="198"/>
@@ -2973,7 +2973,7 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/generalsettings.ui" line="205"/>
         <source>Show sync folders in &amp;Explorer&apos;s navigation pane</source>
-        <translation type="unfinished"/>
+        <translation>Vis synkroniseringsmapper i &amp;Stifinders navigationsrude</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="301"/>
@@ -2994,7 +2994,7 @@ Please consider removing this folder from the account and adding it again.</sour
         <location filename="../src/gui/generalsettings.ui" line="319"/>
         <location filename="../src/gui/generalsettings.cpp" line="469"/>
         <source>Create Debug Archive</source>
-        <translation type="unfinished"/>
+        <translation>Opret fejlfindingsarkiv</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="265"/>
@@ -3014,7 +3014,7 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/generalsettings.ui" line="295"/>
         <source>Update channel</source>
-        <translation type="unfinished"/>
+        <translation>Opdateringskanal</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="183"/>
@@ -3024,12 +3024,12 @@ Please consider removing this folder from the account and adding it again.</sour
     <message>
         <location filename="../src/gui/generalsettings.ui" line="348"/>
         <source>&amp;Automatically check for updates</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Søg automatisk efter opdateringer</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="364"/>
         <source>Check Now</source>
-        <translation type="unfinished"/>
+        <translation>Tjek nu</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.ui" line="391"/>
@@ -3143,7 +3143,7 @@ Downgrading versions is not possible immediately: changing from stable to enterp
     <message>
         <location filename="../src/gui/generalsettings.cpp" line="475"/>
         <source>Debug Archive Created</source>
-        <translation type="unfinished"/>
+        <translation>Fejlfindingsarkiv oprettet</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.cpp" line="475"/>
@@ -3593,17 +3593,17 @@ Note that using any logging command line options will override this setting.</so
     <message>
         <location filename="../src/gui/networksettings.ui" line="176"/>
         <source>Note: proxy settings have no effects for accounts on localhost</source>
-        <translation type="unfinished"/>
+        <translation>Bemærk: proxyindstillinger har ingen virkninger for konti på localhost</translation>
     </message>
     <message>
         <location filename="../src/gui/networksettings.ui" line="249"/>
         <source>Manually specify proxy</source>
-        <translation type="unfinished"/>
+        <translation>Angiv proxy manuelt</translation>
     </message>
     <message>
         <location filename="../src/gui/networksettings.ui" line="259"/>
         <source>No proxy</source>
-        <translation type="unfinished"/>
+        <translation>Ingen proxy</translation>
     </message>
     <message>
         <location filename="../src/gui/networksettings.ui" line="285"/>
@@ -4874,7 +4874,7 @@ This is a new, experimental mode. If you decide to use it, please report any iss
         <location filename="../src/gui/settingsdialog.cpp" line="102"/>
         <source>%1 Settings</source>
         <extracomment>This name refers to the application name e.g Nextcloud</extracomment>
-        <translation type="unfinished"/>
+        <translation>%1 Indstillinger</translation>
     </message>
     <message>
         <location filename="../src/gui/settingsdialog.cpp" line="120"/>
@@ -5763,7 +5763,7 @@ Server replied with error: %2</source>
     <message>
         <location filename="../src/gui/userstatusselectormodel.cpp" line="171"/>
         <source>Could not set status. Make sure you are connected to the server.</source>
-        <translation type="unfinished"/>
+        <translation>Kunne ikke angive status. Sørg for at du er forbundet til serveren.</translation>
     </message>
     <message>
         <location filename="../src/gui/userstatusselectormodel.cpp" line="175"/>
@@ -6254,12 +6254,12 @@ Server replied with error: %2</source>
     <message>
         <location filename="../src/gui/generalsettings.cpp" line="131"/>
         <source>Failed to create debug archive</source>
-        <translation type="unfinished"/>
+        <translation>Fejl ved oprettelse af fejlfindingsarkiv</translation>
     </message>
     <message>
         <location filename="../src/gui/generalsettings.cpp" line="132"/>
         <source>Could not create debug archive in selected location!</source>
-        <translation type="unfinished"/>
+        <translation>Kunne ikke oprette fejlfindingsarkiv på den valgte lokation!</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/usermodel.cpp" line="763"/>
@@ -6667,7 +6667,7 @@ Server replied with error: %2</source>
     <message>
         <location filename="../src/gui/tray/UserLine.qml" line="165"/>
         <source>Set status</source>
-        <translation type="unfinished"/>
+        <translation>Angiv status</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/UserLine.qml" line="173"/>
@@ -7267,7 +7267,7 @@ Server replied with error: %2</source>
     <message>
         <location filename="../src/gui/tray/TrayFoldersMenuButton.qml" line="55"/>
         <source>Open local folder</source>
-        <translation type="unfinished"/>
+        <translation>Åbn lokal mappe</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/TrayFoldersMenuButton.qml" line="70"/>
@@ -7287,7 +7287,7 @@ Server replied with error: %2</source>
     <message>
         <location filename="../src/gui/tray/TrayFoldersMenuButton.qml" line="184"/>
         <source>Open local folder &quot;%1&quot;</source>
-        <translation type="unfinished"/>
+        <translation>Åbn lokal mappe &quot;%1&quot;</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/TrayFoldersMenuButton.qml" line="184"/>
@@ -7297,7 +7297,7 @@ Server replied with error: %2</source>
     <message>
         <location filename="../src/gui/tray/TrayFoldersMenuButton.qml" line="198"/>
         <source>Open %1 in file explorer</source>
-        <translation type="unfinished"/>
+        <translation>Åbn %1 i stifinder</translation>
     </message>
     <message>
         <location filename="../src/gui/tray/TrayFoldersMenuButton.qml" line="203"/>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -2489,7 +2489,9 @@ Alternativ können Sie auch alle gelöschten Dateien wiederherstellen, indem Sie
         <source>Multiple accounts are sharing the folder %1.
 This configuration is known to lead to data loss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>Mehrere Konten teilen sich den Ordner %1.
+Diese Konfiguration führt bekanntermaßen zu Datenverlust und wird nicht mehr unterstützt.
+Sie sollten in Erwägung ziehen, diesen Ordner aus dem Konto zu entfernen und erneut hinzuzufügen.</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="2047"/>

--- a/translations/client_en_GB.ts
+++ b/translations/client_en_GB.ts
@@ -2490,7 +2490,9 @@ Alternatively, you can restore all deleted files by downloading them from the se
         <source>Multiple accounts are sharing the folder %1.
 This configuration is known to lead to data loss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>Multiple accounts are sharing the folder %1.
+This configuration is known to lead to data loss and is no longer supported.
+Please consider removing this folder from the account and adding it again.</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="2047"/>

--- a/translations/client_ga.ts
+++ b/translations/client_ga.ts
@@ -2453,7 +2453,7 @@ De rogha air sin, is féidir leat gach comhad a scriosadh a chur ar ais trína n
     <message>
         <location filename="../src/gui/folderman.cpp" line="1810"/>
         <source>The folder %1 is used in a folder sync connection!</source>
-        <translation type="unfinished"/>
+        <translation>Úsáidtear fillteán %1 i gceangal sioncronaithe fillteáin!</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="1656"/>
@@ -2490,14 +2490,18 @@ De rogha air sin, is féidir leat gach comhad a scriosadh a chur ar ais trína n
         <source>Multiple accounts are sharing the folder %1.
 This configuration is known to lead to data loss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>Tá an fillteán %1 á roinnt ag cuntais iolracha.
+Is eol go gcailltear sonraí as an gcumraíocht seo agus ní thacaítear léi a thuilleadh.
+Smaoinigh le do thoil an fillteán seo a bhaint den chuntas agus é a chur leis arís.</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="2047"/>
         <source>Multiple accounts are sharing the folder %1.
 This configuration is know to lead to dataloss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>Tá an fillteán %1 á roinnt ag cuntais iolracha.
+Tá a fhios go gcailltear sonraí as an gcumraíocht seo agus ní thacaítear léi a thuilleadh.
+Smaoinigh le do thoil an fillteán seo a bhaint den chuntas agus é a chur leis arís.</translation>
     </message>
 </context>
 <context>
@@ -5873,7 +5877,7 @@ D&apos;fhreagair an freastalaí le hearráid: % 2</translation>
     <message>
         <location filename="../src/common/vfs.cpp" line="75"/>
         <source>The Virtual filesystem feature does not support a drive as sync root</source>
-        <translation type="unfinished"/>
+        <translation>Ní thacaíonn gné an chórais comhaid fhíorúil le tiomántán mar fhréamh sioncronaithe</translation>
     </message>
     <message>
         <location filename="../src/common/vfs.cpp" line="75"/>
@@ -5883,7 +5887,7 @@ D&apos;fhreagair an freastalaí le hearráid: % 2</translation>
     <message>
         <location filename="../src/common/vfs.cpp" line="83"/>
         <source>The Virtual filesystem feature is not supported on network drives</source>
-        <translation type="unfinished"/>
+        <translation>Ní thacaítear leis an ngné córas comhaid Fíorúil ar thiomáineann líonra</translation>
     </message>
 </context>
 <context>

--- a/translations/client_gl.ts
+++ b/translations/client_gl.ts
@@ -2490,14 +2490,18 @@ Como alternativa, pode restaurar todos os ficheiros eliminados descargándoos do
         <source>Multiple accounts are sharing the folder %1.
 This configuration is known to lead to data loss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>Varias contas están a compartir o cartafol %1
+Sábese que esta configuración leva á perda de datos e xa non está admitida.
+Considere eliminar este cartafol da conta e engadilo de novo.</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="2047"/>
         <source>Multiple accounts are sharing the folder %1.
 This configuration is know to lead to dataloss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>Varias contas están a compartir o cartafol %1
+Sábese que esta configuración leva á perda de datos e xa non está admitida.
+Considere eliminar este cartafol da conta e engadilo de novo.</translation>
     </message>
 </context>
 <context>
@@ -5872,7 +5876,7 @@ O servidor respondeu co erro: %2</translation>
     <message>
         <location filename="../src/common/vfs.cpp" line="75"/>
         <source>The Virtual filesystem feature does not support a drive as sync root</source>
-        <translation type="unfinished"/>
+        <translation>A funcionalidade do sistema de ficheiros virtual non admite unha unidade como raíz de sincronización</translation>
     </message>
     <message>
         <location filename="../src/common/vfs.cpp" line="75"/>
@@ -5882,7 +5886,7 @@ O servidor respondeu co erro: %2</translation>
     <message>
         <location filename="../src/common/vfs.cpp" line="83"/>
         <source>The Virtual filesystem feature is not supported on network drives</source>
-        <translation type="unfinished"/>
+        <translation>A funcionalidade do sistema de ficheiros virtual non é compatíbel coas unidades de rede</translation>
     </message>
 </context>
 <context>

--- a/translations/client_sv.ts
+++ b/translations/client_sv.ts
@@ -2453,7 +2453,7 @@ Alternativt kan du återställa alla raderade filer genom att ladda ner dem frå
     <message>
         <location filename="../src/gui/folderman.cpp" line="1810"/>
         <source>The folder %1 is used in a folder sync connection!</source>
-        <translation type="unfinished"/>
+        <translation>Mappen %1 används i en synkroniseringsanslutning!</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="1656"/>
@@ -2490,14 +2490,18 @@ Alternativt kan du återställa alla raderade filer genom att ladda ner dem frå
         <source>Multiple accounts are sharing the folder %1.
 This configuration is known to lead to data loss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>Flera konton delar mappen %1.
+Denna konfiguration är känd för att leda till dataförlust och stöds inte längre.
+Överväg att ta bort den här mappen från kontot och lägg till den igen.</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="2047"/>
         <source>Multiple accounts are sharing the folder %1.
 This configuration is know to lead to dataloss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>Flera konton delar mappen %1.
+Denna konfiguration är känd för att leda till dataförlust och stöds inte längre.
+Överväg att ta bort den här mappen från kontot och lägg till den igen.</translation>
     </message>
 </context>
 <context>
@@ -5873,7 +5877,7 @@ Servern svarade med fel: %2</translation>
     <message>
         <location filename="../src/common/vfs.cpp" line="75"/>
         <source>The Virtual filesystem feature does not support a drive as sync root</source>
-        <translation type="unfinished"/>
+        <translation>Funktionen virtuellt filsystem stöder inte en enhet som toppnivå för synkronisering</translation>
     </message>
     <message>
         <location filename="../src/common/vfs.cpp" line="75"/>
@@ -5883,7 +5887,7 @@ Servern svarade med fel: %2</translation>
     <message>
         <location filename="../src/common/vfs.cpp" line="83"/>
         <source>The Virtual filesystem feature is not supported on network drives</source>
-        <translation type="unfinished"/>
+        <translation>Funktionen virtuellt filsystem stöds inte på nätverksenheter</translation>
     </message>
 </context>
 <context>

--- a/translations/client_zh_HK.ts
+++ b/translations/client_zh_HK.ts
@@ -2491,7 +2491,8 @@ Alternatively, you can restore all deleted files by downloading them from the se
         <source>Multiple accounts are sharing the folder %1.
 This configuration is known to lead to data loss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>多個帳戶正在共享資料夾 %1。
+這種配置已知會導致數據丟失，並且不再受支持。請考慮從帳戶中移除此資料夾並重新添加。</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="2047"/>

--- a/translations/client_zh_TW.ts
+++ b/translations/client_zh_TW.ts
@@ -2453,7 +2453,7 @@ Alternatively, you can restore all deleted files by downloading them from the se
     <message>
         <location filename="../src/gui/folderman.cpp" line="1810"/>
         <source>The folder %1 is used in a folder sync connection!</source>
-        <translation type="unfinished"/>
+        <translation>資料夾 %1 用於資料夾同步連線！</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="1656"/>
@@ -2490,14 +2490,18 @@ Alternatively, you can restore all deleted files by downloading them from the se
         <source>Multiple accounts are sharing the folder %1.
 This configuration is known to lead to data loss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>有多個帳號正在共用資料夾 %1。
+這種組態已知會導致資料遺失且不再支援。
+請考慮從帳號中移除此資料夾並重新新增。</translation>
     </message>
     <message>
         <location filename="../src/gui/folderman.cpp" line="2047"/>
         <source>Multiple accounts are sharing the folder %1.
 This configuration is know to lead to dataloss and is no longer supported.
 Please consider removing this folder from the account and adding it again.</source>
-        <translation type="unfinished"/>
+        <translation>有多個帳號正在共用資料夾 %1。
+這種組態已知會導致資料遺失且不再支援。
+請考慮從帳號中移除此資料夾並重新新增。</translation>
     </message>
 </context>
 <context>
@@ -5873,7 +5877,7 @@ Server replied with error: %2</source>
     <message>
         <location filename="../src/common/vfs.cpp" line="75"/>
         <source>The Virtual filesystem feature does not support a drive as sync root</source>
-        <translation type="unfinished"/>
+        <translation>虛擬檔案系統功能不支援將磁碟機作為同步根目錄</translation>
     </message>
     <message>
         <location filename="../src/common/vfs.cpp" line="75"/>
@@ -5883,7 +5887,7 @@ Server replied with error: %2</source>
     <message>
         <location filename="../src/common/vfs.cpp" line="83"/>
         <source>The Virtual filesystem feature is not supported on network drives</source>
-        <translation type="unfinished"/>
+        <translation>網路磁碟機不支援虛擬檔案系統功能</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fixes: <https://github.com/nextcloud/desktop/issues/7658>  
Same solution as in [owncloud's client](https://github.com/owncloud/client/pull/8750) for the same bug.

<!-- 
Thanks for opening a pull request on the Nextcloud desktop client.

Instead of a Contributor License Agreement (CLA) we use a Developer Certificate of Origin (DCO).
https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin

To accept that DCO, please make sure that you add a line like
Signed-off-by: Random Developer <random@developer.example.org>
at the end of each commit message.

This Signed-off-by trailer can be added automatically by git if you pass --signoff or -s to git commit.
See also:
https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---no-signoff
-->
